### PR TITLE
tests: Remove conditional skipping when Typst unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ The path to the Typst CLI can be configured through the `TYPST_PATH` environment
 cargo test
 ```
 
-Note that some tests require Typst to be installed and will be skipped if it's not available.
-
 ### Example
 
 The crate includes an example that demonstrates how to generate an image:
@@ -82,7 +80,7 @@ The crate includes an example that demonstrates how to generate an image:
 cargo run --example test_generator
 ```
 
-This will generate a test image in the current directory. This will also test the avatar fetching functionality, which requires network access and isn't run as part of the automated tests.
+This will generate a test image in the current directory
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -752,27 +752,7 @@ mod tests {
         }
     }
 
-    fn skip_if_typst_unavailable() -> bool {
-        if matches!(var("CI"), Ok(Some(_))) {
-            // Do not skip tests in CI environments, even if Typst is unavailable.
-            // We want the test to fail instead of silently skipping.
-            return false;
-        }
-
-        std::process::Command::new("typst")
-            .arg("--version")
-            .output()
-            .inspect_err(|_| {
-                eprintln!("Skipping test: typst binary not found in PATH");
-            })
-            .is_err()
-    }
-
     async fn generate_image(data: OgImageData<'_>) -> Option<Vec<u8>> {
-        if skip_if_typst_unavailable() {
-            return None;
-        }
-
         let generator =
             OgImageGenerator::from_environment().expect("Failed to create OgImageGenerator");
 


### PR DESCRIPTION
When this project was part of the crates.io repository, it made sense to keep the rest of the test suite running even if Typst was not installed. Since this is a dedicated project now, we can remove the conditional skipping, since anyone working on this project should have Typst installed.