### PR TITLE
Unrestrict dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ unused = "warn"
 unescaped_backticks = "warn"
 
 [dependencies]
-reqwest = "=0.12.22"
-serde = { version = "=1.0.219", features = ["derive"] }
-serde_json = "=1.0.140"
-tempfile = "=3.20.0"
-thiserror = "=2.0.12"
-tokio = { version = "=1.46.1", features = ["process", "fs"] }
-tracing = "=0.1.41"
+reqwest = "0.12.22"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+tempfile = "3.20.0"
+thiserror = "2.0.12"
+tokio = { version = "1.46.1", features = ["process", "fs"] }
+tracing = "0.1.41"
 
 [dev-dependencies]
 insta = "=1.43.1"


### PR DESCRIPTION
In the crates.io repo we pin all dependency versions, but now that this is a published crates on crates.io we shouldn't be doing this anymore to avoid conflicts in downstream projects.