### PR TITLE
renovate: Use `rangeStrategy: bump` for Rust dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,4 +8,10 @@
     ":semanticCommitsDisabled",
     "customManagers:githubActionsVersions",
   ],
+  packageRules: [
+    {
+      matchManagers: ["cargo"],
+      rangeStrategy: "bump",
+    },
+  ],
 }


### PR DESCRIPTION
Otherwise we risk relying on features only available in newer dependency versions since the lockfiles would have newer versions than specified in the manifest.