### PR TITLE
Use oxipng library instead of CLI for PNG optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,10 +68,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
@@ -174,6 +192,7 @@ version = "0.2.3"
 dependencies = [
  "insta",
  "mockito",
+ "oxipng",
  "reqwest",
  "serde",
  "serde_json",
@@ -183,6 +202,40 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "displaydoc"
@@ -200,6 +253,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -270,6 +329,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -614,6 +679,7 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "rayon",
  "serde",
  "serde_core",
 ]
@@ -732,6 +798,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libdeflate-sys"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
+dependencies = [
+ "libdeflate-sys",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +925,22 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "oxipng"
+version = "10.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eaaaa67c73558edaf5270e28abdf8d0663d88e8e7570cf894eff25305f4ed2"
+dependencies = [
+ "bitvec",
+ "indexmap",
+ "libdeflater",
+ "log",
+ "rayon",
+ "rgb",
+ "rustc-hash",
+ "zopfli",
+]
 
 [[package]]
 name = "parking_lot"
@@ -992,6 +1092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1124,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1094,6 +1220,15 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1359,6 +1494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1606,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -2200,6 +2347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,3 +2463,15 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,12 @@ unused = "warn"
 [lints.rustdoc]
 unescaped_backticks = "warn"
 
+[features]
+default = ["oxipng"]
+oxipng = ["dep:oxipng"]
+
 [dependencies]
+oxipng = { version = "10", optional = true, default-features = false, features = ["parallel", "zopfli"] }
 reqwest = "0.13.4"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The generated images include:
 - The [Fira Sans](https://github.com/mozilla/Fira) font must be installed on your system (or configured via the `TYPST_FONT_PATH` environment variable).
 - The [Noto CJK](https://github.com/notofonts/noto-cjk) font may optionally be installed for CJK character support.
 - The [Noto Color Emoji](https://github.com/googlefonts/noto-emoji/) font may optionally be installed for Emoji support.
-- The [oxipng](https://github.com/shssoichiro/oxipng) CLI may optionally be installed for PNG file size optimization.
 
 ## Usage
 
@@ -73,7 +72,10 @@ The following environment variables can be used to configure the image generatio
 
 - `TYPST_PATH` - Path to the Typst CLI binary
 - `TYPST_FONT_PATH` - Additional font directory
-- `OXIPNG_PATH` - Path to the `oxipng` binary for PNG optimization
+
+### Cargo Features
+
+- `oxipng` (enabled by default) - Bundles the [oxipng](https://github.com/shssoichiro/oxipng) library for lossless PNG file size optimization. Disable it with `default-features = false`. When enabled, call `OgImageGenerator::with_oxipng()` to optimize generated images.
 
 ## Development
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,16 +73,16 @@ impl<'a> OgImageAuthorData<'a> {
 pub struct OgImageGenerator {
     typst_binary_path: PathBuf,
     typst_font_path: Option<PathBuf>,
-    oxipng_binary_path: PathBuf,
+    #[cfg(feature = "oxipng")]
+    optimize_png: bool,
 }
 
 impl OgImageGenerator {
-    /// Creates a new `OgImageGenerator` with default binary paths.
+    /// Creates a new `OgImageGenerator` with the default Typst binary path.
     ///
-    /// Uses "typst" and "oxipng" as default binary paths, assuming they are
-    /// available in PATH. Use [`with_typst_path()`](Self::with_typst_path) and
-    /// [`with_oxipng_path()`](Self::with_oxipng_path) to customize the
-    /// binary paths.
+    /// Uses "typst" as the default binary path, assuming it is available in
+    /// PATH. Use [`with_typst_path()`](Self::with_typst_path) to customize the
+    /// binary path.
     ///
     /// # Examples
     ///
@@ -132,7 +132,6 @@ impl OgImageGenerator {
     pub fn from_environment() -> Result<Self, OgImageError> {
         let typst_path = var("TYPST_PATH").map_err(OgImageError::EnvVarError)?;
         let font_path = var("TYPST_FONT_PATH").map_err(OgImageError::EnvVarError)?;
-        let oxipng_path = var("OXIPNG_PATH").map_err(OgImageError::EnvVarError)?;
 
         let mut generator = OgImageGenerator::default();
 
@@ -149,13 +148,6 @@ impl OgImageGenerator {
         } else {
             debug!("No custom font path specified, using Typst default font discovery");
         }
-
-        if let Some(ref path) = oxipng_path {
-            debug!(oxipng_path = %path, "Using custom oxipng binary path from environment");
-            generator.oxipng_binary_path = PathBuf::from(path);
-        } else {
-            debug!("OXIPNG_PATH not set, defaulting to 'oxipng' in PATH");
-        };
 
         Ok(generator)
     }
@@ -199,22 +191,21 @@ impl OgImageGenerator {
         self
     }
 
-    /// Sets the oxipng binary path for PNG optimization.
+    /// Enables in-process PNG optimization using the `oxipng` library.
     ///
-    /// This allows specifying a custom path to the oxipng binary for PNG optimization.
-    /// If not set, defaults to "oxipng" which assumes the binary is available in PATH.
+    /// Optimization is disabled by default. Failures are logged and never abort
+    /// image generation, so optimization remains best-effort.
     ///
     /// # Examples
     ///
     /// ```
-    /// use std::path::PathBuf;
     /// use crates_io_og_image::OgImageGenerator;
     ///
-    /// let generator = OgImageGenerator::default()
-    ///     .with_oxipng_path(PathBuf::from("/usr/local/bin/oxipng"));
+    /// let generator = OgImageGenerator::default().with_oxipng();
     /// ```
-    pub fn with_oxipng_path(mut self, oxipng_path: PathBuf) -> Self {
-        self.oxipng_binary_path = oxipng_path;
+    #[cfg(feature = "oxipng")]
+    pub fn with_oxipng(mut self) -> Self {
+        self.optimize_png = true;
         self
     }
 
@@ -490,7 +481,10 @@ impl OgImageGenerator {
         );
 
         // After successful Typst compilation, optimize the PNG
-        self.optimize_png(output_file.path()).await;
+        #[cfg(feature = "oxipng")]
+        if self.optimize_png {
+            Self::optimize_png(output_file.path()).await;
+        }
 
         let duration = start_time.elapsed();
         info!(
@@ -500,56 +494,47 @@ impl OgImageGenerator {
         Ok(output_file)
     }
 
-    /// Optimizes a PNG file using oxipng.
+    /// Optimizes a PNG file in place using the `oxipng` library.
     ///
     /// This method attempts to reduce the file size of a PNG using lossless compression.
     /// All errors are handled internally and logged as warnings. The method never fails
     /// to ensure PNG optimization is truly optional.
-    async fn optimize_png(&self, png_file: &Path) {
-        debug!(
-            input_file = %png_file.display(),
-            oxipng_path = %self.oxipng_binary_path.display(),
-            "Starting PNG optimization"
-        );
+    #[cfg(feature = "oxipng")]
+    async fn optimize_png(png_file: &Path) {
+        use oxipng::{InFile, Options, OutFile, StripChunks};
+
+        debug!(input_file = %png_file.display(), "Starting PNG optimization");
 
         let start_time = std::time::Instant::now();
 
-        let mut command = Command::new(&self.oxipng_binary_path);
+        let path = png_file.to_path_buf();
+        let result = tokio::task::spawn_blocking(move || {
+            let input = InFile::from(path);
+            // `path: None` writes the output back to the input file.
+            let output = OutFile::Path {
+                path: None,
+                preserve_attrs: false,
+            };
 
-        // Default optimization level for speed/compression balance
-        command.arg("--opt").arg("2");
+            let mut options = Options::from_preset(2);
+            options.strip = StripChunks::Safe;
 
-        // Remove safe-to-remove metadata
-        command.arg("--strip").arg("safe");
+            oxipng::optimize(&input, &output, &options)
+        })
+        .await;
 
-        // Overwrite the input PNG file
-        command.arg(png_file);
-
-        // Clear environment variables to avoid leaking sensitive data
-        command.env_clear();
-
-        // Preserve environment variables needed for running oxipng
-        if let Ok(path) = std::env::var("PATH") {
-            command.env("PATH", path);
-        }
-
-        let output = command.output().await;
         let duration = start_time.elapsed();
 
-        match output {
-            Ok(output) if output.status.success() => {
+        match result {
+            Ok(Ok((input_size, output_size))) => {
                 debug!(
                     duration_ms = duration.as_millis(),
-                    "PNG optimization completed successfully"
+                    "PNG optimization reduced image from {input_size} to {output_size} bytes"
                 );
             }
-            Ok(output) => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                let stdout = String::from_utf8_lossy(&output.stdout);
+            Ok(Err(err)) => {
                 warn!(
-                    exit_code = ?output.status.code(),
-                    stderr = %stderr,
-                    stdout = %stdout,
+                    error = %err,
                     duration_ms = duration.as_millis(),
                     input_file = %png_file.display(),
                     "PNG optimization failed, continuing with unoptimized image"
@@ -559,8 +544,7 @@ impl OgImageGenerator {
                 warn!(
                     error = %err,
                     input_file = %png_file.display(),
-                    oxipng_path = %self.oxipng_binary_path.display(),
-                    "Failed to execute oxipng, continuing with unoptimized image"
+                    "PNG optimization task panicked, continuing with unoptimized image"
                 );
             }
         }
@@ -568,14 +552,15 @@ impl OgImageGenerator {
 }
 
 impl Default for OgImageGenerator {
-    /// Creates a default `OgImageGenerator` with default binary paths.
+    /// Creates a default `OgImageGenerator` with the default Typst binary path.
     ///
-    /// Uses "typst" and "oxipng" as default binary paths, assuming they are available in PATH.
+    /// Uses "typst" as the default binary path, assuming it is available in PATH.
     fn default() -> Self {
         Self {
             typst_binary_path: PathBuf::from("typst"),
             typst_font_path: None,
-            oxipng_binary_path: PathBuf::from("oxipng"),
+            #[cfg(feature = "oxipng")]
+            optimize_png: false,
         }
     }
 }
@@ -753,6 +738,11 @@ mod tests {
     async fn generate_image(data: OgImageData<'_>) -> Option<Vec<u8>> {
         let generator =
             OgImageGenerator::from_environment().expect("Failed to create OgImageGenerator");
+
+        // Snapshots are optimized PNGs, so the tests must opt into optimization.
+        // The `cfg` keeps the test binary compiling under `--no-default-features`.
+        #[cfg(feature = "oxipng")]
+        let generator = generator.with_oxipng();
 
         let temp_file = generator
             .generate(data)


### PR DESCRIPTION
Shelling out to the oxipng CLI required the binary to be installed and discoverable at runtime. Linking the library instead removes that external runtime dependency and runs optimization in-process.

The library is pulled in through a new `oxipng` cargo feature, enabled by default but removable via `default-features = false` for consumers that don't need PNG optimization. With the feature enabled, optimization is opt-in per generator via the new `with_oxipng()` method.

The `OXIPNG_PATH` environment variable and `with_oxipng_path()` builder are removed. Optimization settings (preset 2, strip safe) are unchanged, so generated images stay byte-for-byte identical, as verified by the existing snapshot tests.