### PR TITLE
CI: Remove oxipng CLI install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
-  # renovate: datasource=github-releases depName=shssoichiro/oxipng versioning=semver
-  OXIPNG_VERSION: 10.1.1
   # renovate: datasource=github-releases depName=typst/typst versioning=semver
   TYPST_VERSION: 0.14.2
 
@@ -35,14 +33,6 @@ jobs:
         sudo mv "typst-x86_64-unknown-linux-musl/typst" /usr/local/bin/
         rm -rf "typst-x86_64-unknown-linux-musl" "typst-x86_64-unknown-linux-musl.tar.xz"
         typst --version
-
-    - name: Install oxipng
-      run: |
-        wget -q "https://github.com/shssoichiro/oxipng/releases/download/v${OXIPNG_VERSION}/oxipng-${OXIPNG_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-        tar -xf "oxipng-${OXIPNG_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-        sudo mv "oxipng-${OXIPNG_VERSION}-x86_64-unknown-linux-musl/oxipng" /usr/local/bin/
-        rm -rf "oxipng-${OXIPNG_VERSION}-x86_64-unknown-linux-musl" "oxipng-${OXIPNG_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-        oxipng --version
 
     - name: Setup fonts
       run: |


### PR DESCRIPTION
PNG optimization moved to the bundled `oxipng` library in #80, but the CLI install step was left behind. This removes it along with the obsolete `OXIPNG_VERSION` env var.