### PR TITLE
Avoid disk round-trips during image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ async fn main() -> Result<(), OgImageError> {
     };
 
     // Generate the image
-    let temp_file = generator.generate(data).await?;
+    let image = generator.generate(data).await?;
 
-    // The temp_file contains the path to the generated PNG image
-    println!("Image generated at: {}", temp_file.path().display());
+    // `image` contains the raw PNG bytes
+    println!("Generated image: {} bytes", image.len());
 
     Ok(())
 }

--- a/examples/test_generator.rs
+++ b/examples/test_generator.rs
@@ -42,14 +42,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         releases: 5,
     };
     match generator.generate(data).await {
-        Ok(temp_file) => {
+        Ok(image) => {
             let output_path = "test_og_image.png";
-            std::fs::copy(temp_file.path(), output_path)?;
+            std::fs::write(output_path, &image)?;
             println!("Successfully generated image at: {output_path}");
-            println!(
-                "Image file size: {} bytes",
-                std::fs::metadata(output_path)?.len()
-            );
+            println!("Image file size: {} bytes", image.len());
         }
         Err(error) => {
             println!("Failed to generate image: {error}");

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,10 +46,6 @@ pub enum OgImageError {
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
 
-    /// Temporary file creation error.
-    #[error("Failed to create temporary file: {0}")]
-    TempFileError(std::io::Error),
-
     /// Temporary directory creation error.
     #[error("Failed to create temporary directory: {0}")]
     TempDirError(std::io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,8 +436,8 @@ impl OgImageGenerator {
             debug!("Using only system fonts");
         }
 
-        // Pass input and output file paths
-        command.arg(&typ_file_path).arg(output_file.path());
+        // Pass input file path and compile to stdout
+        command.arg(&typ_file_path).arg("-");
 
         // Clear environment variables to avoid leaking sensitive data
         command.env_clear();
@@ -472,8 +472,9 @@ impl OgImageGenerator {
             });
         }
 
-        let output_size_bytes = fs::metadata(output_file.path()).await;
-        let output_size_bytes = output_size_bytes.map(|m| m.len()).unwrap_or(0);
+        #[allow(unused_mut)]
+        let mut png_data = output.stdout;
+        let output_size_bytes = png_data.len();
 
         debug!(
             duration_ms = compilation_duration.as_millis(),
@@ -483,8 +484,11 @@ impl OgImageGenerator {
         // After successful Typst compilation, optimize the PNG
         #[cfg(feature = "oxipng")]
         if self.optimize_png {
-            Self::optimize_png(output_file.path()).await;
+            png_data = Self::optimize_png(png_data).await;
         }
+
+        let output_size_bytes = png_data.len();
+        fs::write(output_file.path(), &png_data).await?;
 
         let duration = start_time.elapsed();
         info!(
@@ -494,58 +498,57 @@ impl OgImageGenerator {
         Ok(output_file)
     }
 
-    /// Optimizes a PNG file in place using the `oxipng` library.
+    /// Optimizes PNG image data in memory using the `oxipng` library.
     ///
-    /// This method attempts to reduce the file size of a PNG using lossless compression.
-    /// All errors are handled internally and logged as warnings. The method never fails
-    /// to ensure PNG optimization is truly optional.
+    /// This method attempts to reduce the size of a PNG using lossless compression
+    /// and returns the optimized data. On failure it returns the original data
+    /// unchanged. All errors are handled internally and logged as warnings to
+    /// ensure PNG optimization is truly optional.
     #[cfg(feature = "oxipng")]
-    async fn optimize_png(png_file: &Path) {
-        use oxipng::{InFile, Options, OutFile, StripChunks};
+    async fn optimize_png(data: Vec<u8>) -> Vec<u8> {
+        use oxipng::{Options, StripChunks};
+        use std::sync::Arc;
 
-        debug!(input_file = %png_file.display(), "Starting PNG optimization");
+        let input_size = data.len();
+        debug!("Starting PNG optimization");
 
         let start_time = std::time::Instant::now();
 
-        let path = png_file.to_path_buf();
+        let data = Arc::new(data);
+        let task_data = data.clone();
         let result = tokio::task::spawn_blocking(move || {
-            let input = InFile::from(path);
-            // `path: None` writes the output back to the input file.
-            let output = OutFile::Path {
-                path: None,
-                preserve_attrs: false,
-            };
-
             let mut options = Options::from_preset(2);
             options.strip = StripChunks::Safe;
 
-            oxipng::optimize(&input, &output, &options)
+            oxipng::optimize_from_memory(&task_data, &options)
         })
         .await;
 
         let duration = start_time.elapsed();
 
         match result {
-            Ok(Ok((input_size, output_size))) => {
+            Ok(Ok(optimized)) => {
+                let output_size = optimized.len();
                 debug!(
                     duration_ms = duration.as_millis(),
                     "PNG optimization reduced image from {input_size} to {output_size} bytes"
                 );
+                optimized
             }
             Ok(Err(err)) => {
                 warn!(
                     error = %err,
                     duration_ms = duration.as_millis(),
-                    input_file = %png_file.display(),
                     "PNG optimization failed, continuing with unoptimized image"
                 );
+                Arc::unwrap_or_clone(data)
             }
             Err(err) => {
                 warn!(
                     error = %err,
-                    input_file = %png_file.display(),
                     "PNG optimization task panicked, continuing with unoptimized image"
                 );
+                Arc::unwrap_or_clone(data)
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use tempfile::NamedTempFile;
 use tokio::fs;
 use tokio::process::Command;
 use tracing::{debug, error, info, instrument, warn};
@@ -325,7 +324,7 @@ impl OgImageGenerator {
     ///
     /// This method creates a temporary directory with all the necessary files
     /// to create the OpenGraph image, compiles it to PNG using the Typst
-    /// binary, and returns the resulting image as a `NamedTempFile`.
+    /// binary, and returns the resulting image as raw PNG bytes.
     ///
     /// # Examples
     ///
@@ -346,8 +345,8 @@ impl OgImageGenerator {
     ///     crate_size: 100,
     ///     releases: 10,
     /// };
-    /// let image_file = generator.generate(data).await?;
-    /// println!("Generated image at: {:?}", image_file.path());
+    /// let image = generator.generate(data).await?;
+    /// println!("Generated image: {} bytes", image.len());
     /// # Ok(())
     /// # }
     /// ```
@@ -356,7 +355,7 @@ impl OgImageGenerator {
         crate.version = %data.version,
         author_count = data.authors.len(),
     ))]
-    pub async fn generate(&self, data: OgImageData<'_>) -> Result<NamedTempFile, OgImageError> {
+    pub async fn generate(&self, data: OgImageData<'_>) -> Result<Vec<u8>, OgImageError> {
         let start_time = std::time::Instant::now();
         info!("Starting OpenGraph image generation");
 
@@ -404,10 +403,6 @@ impl OgImageGenerator {
         let typ_file_path = temp_dir.path().join("og-image.typ");
         debug!(template_path = %typ_file_path.display(), "Copying Typst template");
         fs::write(&typ_file_path, template_content).await?;
-
-        // Create a named temp file for the output PNG
-        let output_file = NamedTempFile::new().map_err(OgImageError::TempFileError)?;
-        debug!(output_path = %output_file.path().display(), "Created output file");
 
         // Serialize data and avatar_map to JSON
         debug!("Serializing data and avatar map to JSON");
@@ -488,14 +483,12 @@ impl OgImageGenerator {
         }
 
         let output_size_bytes = png_data.len();
-        fs::write(output_file.path(), &png_data).await?;
-
         let duration = start_time.elapsed();
         info!(
             duration_ms = duration.as_millis(),
             output_size_bytes, "OpenGraph image generation completed successfully"
         );
-        Ok(output_file)
+        Ok(png_data)
     }
 
     /// Optimizes PNG image data in memory using the `oxipng` library.
@@ -747,12 +740,12 @@ mod tests {
         #[cfg(feature = "oxipng")]
         let generator = generator.with_oxipng();
 
-        let temp_file = generator
+        let image = generator
             .generate(data)
             .await
             .expect("Failed to generate image");
 
-        Some(std::fs::read(temp_file.path()).expect("Failed to read generated image"))
+        Some(image)
     }
 
     #[tokio::test]


### PR DESCRIPTION
We used to write the PNG to disk, have oxipng read it back and write it again, and then the caller read the file once more to get the bytes. That's a lot of disk churn for data we already have in memory.

Now Typst compiles to stdout, oxipng optimizes the bytes in memory, and `generate()` returns the `Vec<u8>` directly. No temp file involved.

Note this changes the return type of `generate()` from `NamedTempFile` to `Vec<u8>`, so it's a breaking change. I also dropped the `TempFileError` variant since nothing constructs it anymore.